### PR TITLE
Skip optimizing variables started with @

### DIFF
--- a/pkg/nolol/converter_test.go
+++ b/pkg/nolol/converter_test.go
@@ -53,10 +53,18 @@ var testProg3 = `
 include "testProg"
 `
 
+var testProg4 = `
+define ev = :mm
+define cv = @cc
+cv++
+ev=cv
+`
+
 var testfs = nolol.MemoryFileSystem{
 	"testProg.nolol":  testProg,
 	"testProg2.nolol": testProg2,
 	"testProg3.nolol": testProg3,
+	"testProg4.nolol": testProg4,
 }
 
 func TestNolol(t *testing.T) {
@@ -118,5 +126,22 @@ func TestLineHandling(t *testing.T) {
 
 	if lines != 8 {
 		t.Fatal("Wrong amount of lines after merging. Expected 8, but got: ", lines)
+	}
+}
+
+func TestVariableNames(t *testing.T) {
+	conv := nolol.NewConverter()
+	file := conv.LoadFileEx("testProg4.nolol", testfs)
+	prog, err := file.Convert()
+
+	printer := &parser.Printer{}
+	actual, _ := printer.Print(prog)
+
+	var expected = "cc++ :mm=cc goto1"
+	if actual != expected {
+		t.Fatal("Output is wrong:", actual)
+	}
+	if err != nil {
+		t.Error(err)
 	}
 }

--- a/pkg/nolol/nast/tokenizer.go
+++ b/pkg/nolol/nast/tokenizer.go
@@ -11,5 +11,6 @@ func NewNololTokenizer() *ast.Tokenizer {
 	tok := ast.NewTokenizer()
 	tok.KeywordRegexes = []*regexp.Regexp{regexp.MustCompile("(?i)^\\b(if|else|end|then|goto|and|or|not|define|while|do|wait|include|macro|insert|break|continue|block|line|expr)\\b")}
 	tok.Symbols = append(tok.Symbols, []string{";", "$"}...)
+	tok.IdentifierRegex = regexp.MustCompile("^:[a-zA-Z0-9_:.]+|^[@a-zA-Z]+[a-zA-Z0-9_.]*")
 	return tok
 }

--- a/pkg/optimizers/variable_name_test.go
+++ b/pkg/optimizers/variable_name_test.go
@@ -70,6 +70,10 @@ func TestOptName(t *testing.T) {
 	if vno.OptimizeVarName("abcde") != "d" {
 		t.Fatal("Did not honor blacklisting")
 	}
+
+	if vno.OptimizeVarName("@abcde") != "abcde" {
+		t.Fatal("Did not honor my variable name choice")
+	}
 }
 
 func TestVarOpt(t *testing.T) {

--- a/pkg/optimizers/variable_names.go
+++ b/pkg/optimizers/variable_names.go
@@ -47,6 +47,10 @@ func (o *VariableNameOptimizer) OptimizeVarName(in string) string {
 	if strings.HasPrefix(in, ":") {
 		return in
 	}
+
+	if strings.HasPrefix(in, "@") {
+		return strings.TrimLeft(in, "@")
+	}
 	lin := strings.ToLower(in)
 	newName, exists := o.variableMappings[lin]
 	if !exists {


### PR DESCRIPTION
## this PR allows set user defined variable names after compile nolol to yolol.
It's need when i preffered custom variable names insted of a,b,c, and in some cases to generate more compact code.
For example: when i tried port ISAN yasm code to nolol code the result code are not optimal because yasm compiler generate
```
t=p-:a t*=t i=p-:b i*=i g=p-:c g*=g f=p-:d f*=f x/=:a*:b*:c*:d goto14
```
and 
nolol compiler generate 
```
ag=af-:a ag*=ag ah=af-:b ah*=ah ai=af-:c ai*=ai aj=af-:d aj*=aj
t/=:a*:b*:c*:d goto15
```

because ISAN has many params

## Which issue(s) this PR fixes**:
It's new feature i don't make it =D

## Sources:
If this PR aims to improve compatibility to the game's implementation (or another existing YOLOL-implementation), please state why you know that the game does it this way.  
(E.g. you tested it ingame yourself, you read it in the wiki etc.)

## Checklist:
- [X] PR is done against develop-branch
- [X] includes tests for everything that changed
- [ ] updated documentation (if necessary)