### PR TITLE
Parser permit inline comments (untested)

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -172,7 +172,7 @@ func (p *Parser) ErrorString(message string, code string) {
 func (p *Parser) Expect(tokenType string, tokenValue string) ast.Position {
 	if !p.IsCurrent(tokenType, tokenValue) {
 		var msg string
-		if tokenType == ast.TypeNewline {
+		if tokenType == ast.TypeNewline || tokenType == ast.TypeComment {
 			msg = "Expected newline"
 		} else {
 			msg = fmt.Sprintf("Expected token '%s'(%s)", tokenValue, tokenType)


### PR DESCRIPTION
## What this PR does / why we need it**:
Allows for inlining of comments in nolol.
This seems like the simple fix, however if this same parser is used between yolol and nolol, it would allow for inline commenting in yolol, which is illegal.
I am not sure if this is the case?
I am also not certain that the compiler will correctly comment out after the token?

## Which issue(s) this PR fixes**:
Fixes #53

## Checklist:
<!-- 
Insert "x" inside the braces to check the box 
e.g. - [x] Foobar
-->
- [x] PR is done against develop-branch
- [ ] includes tests for everything that changed
- [ ] updated documentation (if necessary)