### PR TITLE
Parser permit nolol inline comments (untested)

### DIFF
--- a/pkg/nolol/parser.go
+++ b/pkg/nolol/parser.go
@@ -220,10 +220,10 @@ func (p *Parser) ParseMacroDefinition() *nast.MacroDefinition {
 			if p.IsCurrentType(ast.TypeComment) {
 				mdef.PreComments = append(mdef.PreComments, p.CurrentToken.Value)
 				p.Advance()
-				if p.IsCurrentType(ast.TypeNewline) {
+				if p.IsCurrentType(ast.TypeNewline) || p.IsCurrentType(ast.TypeComment) {
 					p.Advance()
 				}
-			} else if p.IsCurrentType(ast.TypeNewline) {
+			} else if p.IsCurrentType(ast.TypeNewline) || p.IsCurrentType(ast.TypeComment) {
 				mdef.PreComments = append(mdef.PreComments, "")
 				p.Advance()
 			} else {
@@ -255,10 +255,10 @@ func (p *Parser) ParseMacroDefinition() *nast.MacroDefinition {
 			if p.IsCurrentType(ast.TypeComment) {
 				mdef.PostComments = append(mdef.PostComments, p.CurrentToken.Value)
 				p.Advance()
-				if p.IsCurrentType(ast.TypeNewline) {
+				if p.IsCurrentType(ast.TypeNewline) || p.IsCurrentType(ast.TypeComment) {
 					p.Advance()
 				}
-			} else if p.IsCurrentType(ast.TypeNewline) {
+			} else if p.IsCurrentType(ast.TypeNewline) || p.IsCurrentType(ast.TypeComment) {
 				mdef.PostComments = append(mdef.PostComments, "")
 				p.Advance()
 			} else {
@@ -408,7 +408,7 @@ func (p *Parser) ParseMultilineIf() nast.NestableElement {
 
 		p.Expect(ast.TypeKeyword, "then")
 
-		if p.IsCurrentType(ast.TypeNewline) {
+		if p.IsCurrentType(ast.TypeNewline) || p.IsCurrentType(ast.TypeComment) {
 			p.Advance()
 		} else {
 			// We fucked up, this is not a multiline if. Restore saved state and return

--- a/pkg/nolol/parser.go
+++ b/pkg/nolol/parser.go
@@ -147,6 +147,9 @@ func (p *Parser) ParseInclude() *nast.IncludeDirective {
 	incl.File = p.CurrentToken.Value
 	p.Advance()
 	if !p.IsCurrentType(ast.TypeEOF) {
+		if p.IsCurrentType(ast.TypeComment) {
+			p.Advance()
+		}
 		p.Expect(ast.TypeNewline, "")
 	}
 	return incl
@@ -212,6 +215,9 @@ func (p *Parser) ParseMacroDefinition() *nast.MacroDefinition {
 	mdef.Type = p.CurrentToken.Value
 	p.Advance()
 
+	if p.IsCurrentType(ast.TypeComment) {
+		p.Advance()
+	}
 	p.Expect(ast.TypeNewline, "")
 
 	if mdef.Type != nast.MacroTypeBlock {
@@ -245,6 +251,9 @@ func (p *Parser) ParseMacroDefinition() *nast.MacroDefinition {
 		mdef.Code = p.ParseExpression()
 		if mdef.Code == nil {
 			p.ErrorExpectedExpression("inside macro of type expr")
+		}
+		if p.IsCurrentType(ast.TypeComment) {
+			p.Advance()
 		}
 		p.Expect(ast.TypeNewline, "")
 	}
@@ -344,6 +353,9 @@ func (p *Parser) ParseStatementLine() *nast.StatementLine {
 	}
 
 	if !p.IsCurrentType(ast.TypeEOF) {
+		if p.IsCurrentType(ast.TypeComment) {
+			p.Advance()
+		}
 		p.Expect(ast.TypeNewline, "")
 	}
 
@@ -374,6 +386,9 @@ func (p *Parser) ParseDefinition() *nast.Definition {
 	}
 	decl.Value = value
 	if !p.IsCurrentType(ast.TypeEOF) {
+		if p.IsCurrentType(ast.TypeComment) {
+			p.Advance()
+		}
 		p.Expect(ast.TypeNewline, "")
 	}
 	return decl
@@ -436,6 +451,9 @@ func (p *Parser) ParseMultilineIf() nast.NestableElement {
 			p.Advance()
 			continue
 		} else {
+			if p.IsCurrentType(ast.TypeComment) {
+				p.Advance()
+			}
 			p.Expect(ast.TypeNewline, "")
 			mlif.ElseBlock = p.ParseBlock(func() bool {
 				return p.IsCurrent(ast.TypeKeyword, "end")
@@ -447,6 +465,9 @@ func (p *Parser) ParseMultilineIf() nast.NestableElement {
 	p.Expect(ast.TypeKeyword, "end")
 
 	if !p.IsCurrentType(ast.TypeEOF) {
+		if p.IsCurrentType(ast.TypeComment) {
+			p.Advance()
+		}
 		p.Expect(ast.TypeNewline, "")
 	}
 
@@ -470,6 +491,9 @@ func (p *Parser) ParseWhile() nast.NestableElement {
 	}
 
 	p.Expect(ast.TypeKeyword, "do")
+	if p.IsCurrentType(ast.TypeComment) {
+		p.Advance()
+	}
 	p.Expect(ast.TypeNewline, "")
 
 	loop.Block = p.ParseBlock(func() bool {
@@ -479,6 +503,9 @@ func (p *Parser) ParseWhile() nast.NestableElement {
 	p.Expect(ast.TypeKeyword, "end")
 
 	if !p.IsCurrentType(ast.TypeEOF) {
+		if p.IsCurrentType(ast.TypeComment) {
+			p.Advance()
+		}
 		p.Expect(ast.TypeNewline, "")
 	}
 

--- a/pkg/nolol/parser.go
+++ b/pkg/nolol/parser.go
@@ -149,8 +149,9 @@ func (p *Parser) ParseInclude() *nast.IncludeDirective {
 	if !p.IsCurrentType(ast.TypeEOF) {
 		if p.IsCurrentType(ast.TypeComment) {
 			p.Advance()
+		} else {
+			p.Expect(ast.TypeNewline, "")
 		}
-		p.Expect(ast.TypeNewline, "")
 	}
 	return incl
 }
@@ -217,8 +218,9 @@ func (p *Parser) ParseMacroDefinition() *nast.MacroDefinition {
 
 	if p.IsCurrentType(ast.TypeComment) {
 		p.Advance()
+	} else {
+		p.Expect(ast.TypeNewline, "")
 	}
-	p.Expect(ast.TypeNewline, "")
 
 	if mdef.Type != nast.MacroTypeBlock {
 		mdef.PreComments = make([]string, 0)
@@ -254,8 +256,9 @@ func (p *Parser) ParseMacroDefinition() *nast.MacroDefinition {
 		}
 		if p.IsCurrentType(ast.TypeComment) {
 			p.Advance()
+		} else {
+			p.Expect(ast.TypeNewline, "")
 		}
-		p.Expect(ast.TypeNewline, "")
 	}
 
 	if mdef.Type != nast.MacroTypeBlock {
@@ -355,8 +358,10 @@ func (p *Parser) ParseStatementLine() *nast.StatementLine {
 	if !p.IsCurrentType(ast.TypeEOF) {
 		if p.IsCurrentType(ast.TypeComment) {
 			p.Advance()
+		} else {
+			p.Expect(ast.TypeNewline, "")
 		}
-		p.Expect(ast.TypeNewline, "")
+
 	}
 
 	return &ret
@@ -388,8 +393,9 @@ func (p *Parser) ParseDefinition() *nast.Definition {
 	if !p.IsCurrentType(ast.TypeEOF) {
 		if p.IsCurrentType(ast.TypeComment) {
 			p.Advance()
+		} else {
+			p.Expect(ast.TypeNewline, "")
 		}
-		p.Expect(ast.TypeNewline, "")
 	}
 	return decl
 }
@@ -453,8 +459,9 @@ func (p *Parser) ParseMultilineIf() nast.NestableElement {
 		} else {
 			if p.IsCurrentType(ast.TypeComment) {
 				p.Advance()
+			} else {
+				p.Expect(ast.TypeNewline, "")
 			}
-			p.Expect(ast.TypeNewline, "")
 			mlif.ElseBlock = p.ParseBlock(func() bool {
 				return p.IsCurrent(ast.TypeKeyword, "end")
 			})
@@ -467,8 +474,9 @@ func (p *Parser) ParseMultilineIf() nast.NestableElement {
 	if !p.IsCurrentType(ast.TypeEOF) {
 		if p.IsCurrentType(ast.TypeComment) {
 			p.Advance()
+		} else {
+			p.Expect(ast.TypeNewline, "")
 		}
-		p.Expect(ast.TypeNewline, "")
 	}
 
 	return &mlif
@@ -493,8 +501,9 @@ func (p *Parser) ParseWhile() nast.NestableElement {
 	p.Expect(ast.TypeKeyword, "do")
 	if p.IsCurrentType(ast.TypeComment) {
 		p.Advance()
+	} else {
+		p.Expect(ast.TypeNewline, "")
 	}
-	p.Expect(ast.TypeNewline, "")
 
 	loop.Block = p.ParseBlock(func() bool {
 		return p.IsCurrent(ast.TypeKeyword, "end")
@@ -505,8 +514,9 @@ func (p *Parser) ParseWhile() nast.NestableElement {
 	if !p.IsCurrentType(ast.TypeEOF) {
 		if p.IsCurrentType(ast.TypeComment) {
 			p.Advance()
+		} else {
+			p.Expect(ast.TypeNewline, "")
 		}
-		p.Expect(ast.TypeNewline, "")
 	}
 
 	return &loop

--- a/pkg/nolol/parser.go
+++ b/pkg/nolol/parser.go
@@ -220,10 +220,10 @@ func (p *Parser) ParseMacroDefinition() *nast.MacroDefinition {
 			if p.IsCurrentType(ast.TypeComment) {
 				mdef.PreComments = append(mdef.PreComments, p.CurrentToken.Value)
 				p.Advance()
-				if p.IsCurrentType(ast.TypeNewline) || p.IsCurrentType(ast.TypeComment) {
+				if p.IsCurrentType(ast.TypeNewline) {
 					p.Advance()
 				}
-			} else if p.IsCurrentType(ast.TypeNewline) || p.IsCurrentType(ast.TypeComment) {
+			} else if p.IsCurrentType(ast.TypeNewline) {
 				mdef.PreComments = append(mdef.PreComments, "")
 				p.Advance()
 			} else {
@@ -255,10 +255,10 @@ func (p *Parser) ParseMacroDefinition() *nast.MacroDefinition {
 			if p.IsCurrentType(ast.TypeComment) {
 				mdef.PostComments = append(mdef.PostComments, p.CurrentToken.Value)
 				p.Advance()
-				if p.IsCurrentType(ast.TypeNewline) || p.IsCurrentType(ast.TypeComment) {
+				if p.IsCurrentType(ast.TypeNewline) {
 					p.Advance()
 				}
-			} else if p.IsCurrentType(ast.TypeNewline) || p.IsCurrentType(ast.TypeComment) {
+			} else if p.IsCurrentType(ast.TypeNewline) {
 				mdef.PostComments = append(mdef.PostComments, "")
 				p.Advance()
 			} else {
@@ -408,7 +408,7 @@ func (p *Parser) ParseMultilineIf() nast.NestableElement {
 
 		p.Expect(ast.TypeKeyword, "then")
 
-		if p.IsCurrentType(ast.TypeNewline) || p.IsCurrentType(ast.TypeComment) {
+		if p.IsCurrentType(ast.TypeNewline) {
 			p.Advance()
 		} else {
 			// We fucked up, this is not a multiline if. Restore saved state and return

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -172,7 +172,7 @@ func (p *Parser) ErrorString(message string, code string) {
 func (p *Parser) Expect(tokenType string, tokenValue string) ast.Position {
 	if !p.IsCurrent(tokenType, tokenValue) {
 		var msg string
-		if tokenType == ast.TypeNewline || tokenType == ast.TypeComment {
+		if tokenType == ast.TypeNewline {
 			msg = "Expected newline"
 		} else {
 			msg = fmt.Sprintf("Expected token '%s'(%s)", tokenValue, tokenType)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -172,7 +172,7 @@ func (p *Parser) ErrorString(message string, code string) {
 func (p *Parser) Expect(tokenType string, tokenValue string) ast.Position {
 	if !p.IsCurrent(tokenType, tokenValue) {
 		var msg string
-		if tokenType == ast.TypeNewline {
+		if tokenType == ast.TypeNewline || tokenType == ast.TypeComment {
 			msg = "Expected newline"
 		} else {
 			msg = fmt.Sprintf("Expected token '%s'(%s)", tokenValue, tokenType)


### PR DESCRIPTION
## What this PR does / why we need it**:
Should allow for inlining of comments in nolol (untested).

## Which issue(s) this PR fixes**:
Fixes #53

## Checklist:
<!-- 
Insert "x" inside the braces to check the box 
e.g. - [x] Foobar
-->
- [x] PR is done against develop-branch
- [ ] includes tests for everything that changed
- [ ] updated documentation (if necessary)